### PR TITLE
Simplify homepage collapsible layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,34 +48,34 @@
       font-weight:600;
       background:var(--card);
       color:var(--text);
-      margin:10px 0;
+      margin:12px 0;
     }
     a.big:hover,a.big:focus{background:var(--card-hover);outline:none;}
 
     hr{border-top:1px solid var(--border);}
     .note,.muted{color:var(--muted);}
 
-    /* Section separators */
-    .sep{border-top:1px solid var(--border);margin:28px 0;}
-
-    /* === LINK GRID LAYOUT === */
-    .link-grid{
-      display:grid;
-      grid-template-columns:repeat(2,minmax(0,1fr));
-      gap:10px;
-      grid-auto-flow:dense;
+    .section{
+      border:1px solid var(--border);
+      border-radius:var(--rad);
+      margin:28px 0;
+      background:var(--card);
     }
-    .link-grid a.big{
-      margin:0;
-      white-space:normal;
-      word-break:break-word;
+    .section summary{
+      padding:var(--pad);
+      cursor:pointer;
+      font-weight:600;
+      list-style:none;
     }
-    /* any .full item spans entire row */
-    .link-grid a.big.full{grid-column:1 / -1;}
-
-    @media(max-width:540px){
-      .link-grid{grid-template-columns:1fr;}
+    .section summary::-webkit-details-marker{display:none;}
+    .section summary::after{
+      content:"\25BC";
+      float:right;
+      transition:transform 0.2s ease;
     }
+    .section[open] summary::after{transform:rotate(180deg);} 
+    .section-content{padding:0 var(--pad) var(--pad);}
+    .section-content p{margin-top:0;}
   </style>
 </head>
 
@@ -88,84 +88,72 @@
     <strong>Mobile (Text or Call):</strong> (262) 441-3623<br>
     <strong>Pronouns:</strong> they, he, or she (Agender)</p>
 
-    <div class="sep"></div>
+    <hr>
 
-    <h2>Scientific Projects &amp; Publications</h2>
-    <p class="muted">Bachelor of Arts in Sociology &amp; Certificate in Social Science Data Analysis (Western Washington University — 2024)</p>
-    <a class="big" href="https://www.mdpi.com/2071-1050/17/19/8833">Photo Portraiture Enhances Empathy for Birds with Potential Benefits for Conservation and Sustainability (Whitley et al., 2025)</a>
-    <a class="big" href="https://wp.wwu.edu/nsfaward2240023/">Animal Images, Empathy, and Conservation</a>
-    <a class="big" href="https://osf.io/zuqg4">Tripping Hazard: Psychedelics User Typologies and Differential Risks of Health-Related Outcomes (Preregistration)</a>
+    <details class="section">
+      <summary>Scientific Projects &amp; Publications</summary>
+      <div class="section-content">
+        <p class="muted">Bachelor of Arts in Sociology &amp; Certificate in Social Science Data Analysis (Western Washington University — 2024)</p>
+        <a class="big" href="https://www.mdpi.com/2071-1050/17/19/8833">Photo Portraiture Enhances Empathy for Birds with Potential Benefits for Conservation and Sustainability (Whitley et al., 2025)</a>
+        <a class="big" href="https://wp.wwu.edu/nsfaward2240023/">Animal Images, Empathy, and Conservation</a>
+        <a class="big" href="https://osf.io/zuqg4">Tripping Hazard: Psychedelics User Typologies and Differential Risks of Health-Related Outcomes (Preregistration)</a>
+      </div>
+    </details>
 
-    <div class="sep"></div>
+    <details class="section">
+      <summary>Solo Music Project</summary>
+      <div class="section-content">
+        <a class="big" href="https://n8t8m.bandcamp.com/">Bandcamp — name-your-price downloads &amp; back catalog</a>
+        <a class="big" href="https://open.spotify.com/artist/280AVnwGDOdUkVxobsOkqB">Spotify</a>
+        <a class="big" href="https://music.apple.com/us/artist/nate-tatem/1448048139">Apple Music</a>
+        <a class="big" href="https://music.youtube.com/channel/UCMEGdbPtAvLXdA23YEi4zVA">YouTube Music</a>
+        <a class="big" href="https://tidal.com/browse/artist/10782310">TIDAL</a>
+        <a class="big" href="https://music.amazon.co.uk/artists/B07MP1PDHW/nate-tatem">Amazon Music</a>
+        <a class="big" href="https://www.iheart.com/artist/nate-tatem-32695853/">iHeart Radio</a>
+        <a class="big" href="https://www.deezer.com/us/artist/56573232">Deezer</a>
+        <a class="big" href="https://us.napster.com/artist/nate-tatem">Napster</a>
+        <a class="big" href="https://soundcloud.com/natetatem">SoundCloud</a>
+        <a class="big" href="https://audiomack.com/natem262">Audiomack</a>
+        <a class="big" href="https://docs.google.com/document/d/1abXACVfcKZyuInPH2lasOvWFJ02yWaGi-sxxujkwZ5Q/pub">Project Explanation Essay: The Permutation Series (2023)</a>
+      </div>
+    </details>
 
-    <h2>Solo Music Project</h2>
-    <a class="big" href="https://n8t8m.bandcamp.com/">Bandcamp — name-your-price downloads &amp; back catalog</a>
-    <a class="big" href="https://open.spotify.com/artist/280AVnwGDOdUkVxobsOkqB">Spotify</a>
-    <a class="big" href="https://music.apple.com/us/artist/nate-tatem/1448048139">Apple Music</a>
-    <a class="big" href="https://music.youtube.com/channel/UCMEGdbPtAvLXdA23YEi4zVA">YouTube Music</a>
-    <a class="big" href="https://tidal.com/browse/artist/10782310">TIDAL</a>
-    <a class="big" href="https://music.amazon.co.uk/artists/B07MP1PDHW/nate-tatem">Amazon Music</a>
-    <a class="big" href="https://www.iheart.com/artist/nate-tatem-32695853/">iHeart Radio</a>
-    <a class="big" href="https://www.deezer.com/us/artist/56573232">Deezer</a>
-    <a class="big" href="https://us.napster.com/artist/nate-tatem">Napster</a>
-    <a class="big" href="https://soundcloud.com/natetatem">SoundCloud</a>
-    <a class="big" href="https://audiomack.com/natem262">Audiomack</a>
-    <a class="big" href="https://docs.google.com/document/d/1abXACVfcKZyuInPH2lasOvWFJ02yWaGi-sxxujkwZ5Q/pub">Project Explanation Essay: The Permutation Series (2023)</a>
+    <details class="section">
+      <summary>Cold Sludge — Band Member (synthesizers, keyboards, &amp; drums)</summary>
+      <div class="section-content">
+        <a class="big" href="https://beacons.ai/coldsludge">Website — upcoming live shows, music releases, &amp; side projects</a>
+        <a class="big" href="https://www.instagram.com/coldsludge/">Instagram</a>
+        <a class="big" href="https://coldsludge.bandcamp.com/">Bandcamp — stream &amp; purchase</a>
+        <a class="big" href="https://open.spotify.com/artist/2ASDeYcriVq6loGcZhtN5p">Spotify</a>
+        <a class="big" href="https://music.apple.com/us/artist/cold-sludge/1563569938">Apple Music</a>
+        <a class="big" href="mailto:coldsludge@gmail.com" target="_self">coldsludge@gmail.com (booking &amp; inquiries)</a>
+      </div>
+    </details>
 
-    <div class="sep"></div>
+    <details class="section">
+      <summary>Social Media &amp; Online Communities</summary>
+      <div class="section-content">
+        <a class="big" href="https://instagram.com/n8t8m">Instagram</a>
+        <a class="big" href="https://www.snapchat.com/add/n8_t8m">Snapchat</a>
+        <a class="big" href="https://tiktok.com/@n8t8m">TikTok</a>
+        <a class="big" href="https://www.threads.net/@n8t8m?hl=en">Threads</a>
+        <a class="big" href="https://www.goodreads.com/user/show/165867591-nate-tatem">Goodreads (books)</a>
+        <a class="big" href="https://letterboxd.com/n8t8m/">Letterboxd (movies &amp; tv)</a>
+        <a class="big" href="https://rateyourmusic.com/~n8t8m">Rate Your Music (music)</a>
+        <a class="big" href="https://www.linkedin.com/in/n8t8m/">LinkedIn (resume)</a>
+        <a class="big" href="https://www.facebook.com/n8tatem/">Facebook</a>
+      </div>
+    </details>
 
-    <h2>Cold Sludge — Band Member (synthesizers, keyboards, &amp; drums)</h2>
-    <div class="link-grid">
-      <a class="big" href="https://beacons.ai/coldsludge">Website — upcoming live shows, music releases, &amp; side projects</a>
-      <a class="big" href="https://www.instagram.com/coldsludge/">Instagram</a>
-      <a class="big" href="https://coldsludge.bandcamp.com/">Bandcamp — stream &amp; purchase</a>
-      <a class="big" href="https://open.spotify.com/artist/2ASDeYcriVq6loGcZhtN5p">Spotify</a>
-      <a class="big" href="https://music.apple.com/us/artist/cold-sludge/1563569938">Apple Music</a>
-      <a class="big" href="mailto:coldsludge@gmail.com" target="_self">coldsludge@gmail.com (booking &amp; inquiries)</a>
-    </div>
+    <details class="section">
+      <summary>Music Streaming Playlists</summary>
+      <div class="section-content">
+        <a class="big" href="https://sdz.sh/u6JISM">IRL Friends — sharing music from people I know</a>
+      </div>
+    </details>
 
-    <div class="sep"></div>
-
-    <h2>Social Media &amp; Communities</h2>
-    <div class="link-grid">
-      <a class="big" href="https://instagram.com/n8t8m">Instagram</a>
-      <a class="big" href="https://www.snapchat.com/add/n8_t8m">Snapchat</a>
-      <a class="big" href="https://tiktok.com/@n8t8m">TikTok</a>
-      <a class="big" href="https://www.threads.net/@n8t8m?hl=en">Threads</a>
-      <a class="big" href="https://www.goodreads.com/user/show/165867591-nate-tatem">Goodreads (books)</a>
-      <a class="big" href="https://letterboxd.com/n8t8m/">Letterboxd (movies &amp; tv)</a>
-      <a class="big" href="https://rateyourmusic.com/~n8t8m">Rate Your Music (music)</a>
-      <a class="big" href="https://www.linkedin.com/in/n8t8m/">LinkedIn (resume)</a>
-      <a class="big" href="https://www.facebook.com/n8tatem/">Facebook</a>
-    </div>
-
-    <div class="sep"></div>
-
-    <h2>Music Streaming Playlists</h2>
-    <a class="big" href="https://sdz.sh/u6JISM">IRL Friends — sharing music from people I know</a>
-
-    <div class="sep"></div>
-
-    <p class="note">Website built by Nate Tatem in RStudio.</p>
+    <p class="note">Website built by Nate Tatem.</p>
   </div>
 
-  <script>
-    // detect wrapped buttons and make them full-width
-    (function(){
-      function markWrapped(){
-        document.querySelectorAll('.link-grid').forEach(grid=>{
-          grid.querySelectorAll('a.big').forEach(a=>{
-            a.classList.remove('full');
-            const style=getComputedStyle(a);
-            const lineHeight=parseFloat(style.lineHeight);
-            const lines=Math.round(a.scrollHeight/lineHeight);
-            if(lines>1)a.classList.add('full');
-          });
-        });
-      }
-      window.addEventListener('load',markWrapped);
-      window.addEventListener('resize',markWrapped);
-    })();
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the word-based grid script and restore a single-column button layout for clarity
- wrap each link group in an accessible collapsible section so the homepage only shows the headers until expanded
- keep the existing dark theme styling while simplifying the CSS to support the new drop-down structure

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e18a81d62083259a757d2019bd3020